### PR TITLE
10/7

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,8 +13,10 @@
         android:roundIcon="@mipmap/launcher_icon_logo_512_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".settings.BlockedUsersScreen"></activity>
-        <activity android:name=".location.LocationPicker" /> <!-- Google Map declarations -->
+        <activity android:name=".settings.BlockedUsersScreen"
+            android:screenOrientation="portrait"></activity>
+        <activity android:name=".location.LocationPicker"
+            android:screenOrientation="portrait"/> <!-- Google Map declarations -->
         <service
             android:name=".location.NearByActivity"
             android:foregroundServiceType="location" />
@@ -22,40 +24,61 @@
         <meta-data
             android:name="com.google.android.geo.API_KEY"
             android:value="@string/google_maps_key" /> <!-- ******************************************* -->
-        <activity android:name=".location.NearByActivity" />
-        <activity android:name=".userprofile.YourOwnOtherUserView" />
-        <activity android:name=".settings.DeleteAccount" />
-        <activity android:name=".listings.SearchJioActivity" />
-        <activity android:name=".userprofile.ReportUserPage" />
-        <activity android:name=".userprofile.ReviewPage" />
-        <activity android:name=".listings.ViewParticipants" />
-        <activity android:name=".listings.ViewJioActivity" />
-        <activity android:name=".userprofile.OtherUserView" />
-        <activity android:name=".settings.EditProfilePage" />
-        <activity android:name=".post.PostingPage" />
-        <activity android:name=".chat.MessagePage" />
+        <activity android:name=".location.NearByActivity"
+            android:screenOrientation="portrait"/>
+        <activity android:name=".userprofile.YourOwnOtherUserView"
+            android:screenOrientation="portrait"/>
+        <activity android:name=".settings.DeleteAccount"
+            android:screenOrientation="portrait"/>
+        <activity android:name=".listings.SearchJioActivity"
+            android:screenOrientation="portrait"/>
+        <activity android:name=".userprofile.ReportUserPage"
+            android:screenOrientation="portrait"/>
+        <activity android:name=".userprofile.ReviewPage"
+            android:screenOrientation="portrait"/>
+        <activity android:name=".listings.ViewParticipants"
+            android:screenOrientation="portrait"/>
+        <activity android:name=".listings.ViewJioActivity"
+            android:screenOrientation="portrait"/>
+        <activity android:name=".userprofile.OtherUserView"
+            android:screenOrientation="portrait"/>
+        <activity android:name=".settings.EditProfilePage"
+            android:screenOrientation="portrait"/>
+        <activity android:name=".post.PostingPage"
+            android:screenOrientation="portrait"/>
+        <activity android:name=".chat.MessagePage"
+            android:screenOrientation="portrait"/>
         <activity
             android:name=".settings.SettingsPage"
             android:label="@string/title_activity_settings_page"
+            android:screenOrientation="portrait"
             android:parentActivityName=".PostLoginPage" />
-        <activity android:name=".userprofile.ProfilePage" />
+        <activity android:name=".userprofile.ProfilePage"
+            android:screenOrientation="portrait"/>
         <activity
             android:name=".login.LoginPage"
-            android:parentActivityName=".login.MainActivity" />
-        <activity android:name=".login.FirstTimeUserPage" />
+            android:parentActivityName=".login.MainActivity"
+            android:screenOrientation="portrait"/>
+        <activity android:name=".login.FirstTimeUserPage"
+            android:screenOrientation="portrait"/>
         <activity
             android:name=".settings.ChangePasswordPage"
-            android:parentActivityName=".settings.SettingsPage" />
+            android:parentActivityName=".settings.SettingsPage"
+            android:screenOrientation="portrait"/>
         <activity
             android:name=".login.ForgotPasswordPage"
-            android:parentActivityName=".login.LoginPage" />
+            android:parentActivityName=".login.LoginPage"
+            android:screenOrientation="portrait"/>
         <activity
             android:name=".login.RegisterPage"
-            android:parentActivityName=".login.MainActivity" />
+            android:parentActivityName=".login.MainActivity"
+            android:screenOrientation="portrait"/>
         <activity
             android:name=".PostLoginPage"
-            android:theme="@style/AppTheme.NoActionBar" />
-        <activity android:name=".login.MainActivity">
+            android:theme="@style/AppTheme.NoActionBar"
+            android:screenOrientation="portrait"/>
+        <activity android:name=".login.MainActivity"
+            android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/example/jioleh/chat/ChatFragmentViewModel.java
+++ b/app/src/main/java/com/example/jioleh/chat/ChatFragmentViewModel.java
@@ -25,7 +25,7 @@ public class ChatFragmentViewModel extends ViewModel implements databaseOperatio
     }
 
     public void refreshProfiles() {
-        repository.getChatChannels(current_uid);
+        repository.refreshChatChannels(current_uid);
     }
 
     @Override

--- a/app/src/main/java/com/example/jioleh/favourites/FavouritesAdapter.java
+++ b/app/src/main/java/com/example/jioleh/favourites/FavouritesAdapter.java
@@ -72,6 +72,7 @@ public class FavouritesAdapter extends RecyclerView.Adapter<FavouritesAdapter.Fa
         JioActivity activity = activities.get(position);
         if (activity != null) {
             holder.activity_id = activity.getActivityId();
+            holder.host_uid = activity.getHost_uid();
             holder.setUpView(activity);
         }
     }
@@ -111,6 +112,7 @@ public class FavouritesAdapter extends RecyclerView.Adapter<FavouritesAdapter.Fa
         private TextView location;
         private TextView update;
         private String activity_id;
+        private String host_uid;
         private Context currentContext;
 
         //Initialising the holder
@@ -141,6 +143,7 @@ public class FavouritesAdapter extends RecyclerView.Adapter<FavouritesAdapter.Fa
                                     if (documentSnapshot.exists()) {
                                         Intent nextActivity = new Intent(itemView.getContext(), ViewJioActivity.class);
                                         nextActivity.putExtra("activity_id", activity_id);
+                                        nextActivity.putExtra("host_uid", host_uid);
                                         itemView.getContext().startActivity(nextActivity);
                                     } else {
                                         alertDialogDoesNotExist();

--- a/app/src/main/java/com/example/jioleh/favourites/FavouritesFragmentRepository.java
+++ b/app/src/main/java/com/example/jioleh/favourites/FavouritesFragmentRepository.java
@@ -50,7 +50,6 @@ public class FavouritesFragmentRepository {
                         list_of_activities.clear();
 
                         //Adding a list of completable futures
-                        System.out.println("snapshots size = " + snapshots.size());
                         for (DocumentSnapshot documentSnapshot : snapshots) {
                             if (documentSnapshot.exists()) {
                                 list_of_tasks.add(getActivity(documentSnapshot.getId(), current_uid, type));
@@ -93,8 +92,6 @@ public class FavouritesFragmentRepository {
                         for (DocumentSnapshot documentSnapshot : snapshots) {
                             if (documentSnapshot.exists()) {
                                 list_of_tasks.add(getActivity(documentSnapshot.getId(), current_uid, type));
-                            } else {
-                                //remove from joined/liked
                             }
                         }
 

--- a/app/src/main/java/com/example/jioleh/favourites/JoinedFragment.java
+++ b/app/src/main/java/com/example/jioleh/favourites/JoinedFragment.java
@@ -57,7 +57,6 @@ public class JoinedFragment extends Fragment {
             public void onChanged(List<JioActivity> activities) {
                 adapter.setData(activities, false, true);
                 adapter.notifyDataSetChanged();
-                System.out.println("adapter size = " + adapter.getItemCount());
 
                 //Display empty text message
                 if(adapter.getItemCount() == 0) {

--- a/app/src/main/java/com/example/jioleh/listings/ActivityAdapter.java
+++ b/app/src/main/java/com/example/jioleh/listings/ActivityAdapter.java
@@ -44,14 +44,27 @@ public class ActivityAdapter extends RecyclerView.Adapter<ActivityAdapter.Activi
 
     @Override
     public void onBindViewHolder(@NonNull ActivityAdapter.ActivityHolder holder, int position) {
+        holder.setIsRecyclable(false);
+
         JioActivity activity = activities.get(position);
         holder.activity_id = activity.getActivityId();
+        holder.host_uid = activity.getHost_uid();
         holder.setUpView(activity);
     }
 
     @Override
     public int getItemCount() {
         return activities.size();
+    }
+
+    @Override
+    public long getItemId(int position) {
+        return position;
+    }
+
+    @Override
+    public int getItemViewType(int position) {
+        return position;
     }
 
 
@@ -79,6 +92,7 @@ public class ActivityAdapter extends RecyclerView.Adapter<ActivityAdapter.Activi
         private TextView location;
         private TextView currentParticipants;
         private String activity_id;
+        private String host_uid;
 
         //Initialising the holder
         ActivityHolder(@NonNull final View itemView) {
@@ -95,6 +109,7 @@ public class ActivityAdapter extends RecyclerView.Adapter<ActivityAdapter.Activi
                 public void onClick(View v) {
                     Intent nextActivity = new Intent(itemView.getContext(), ViewJioActivity.class);
                     nextActivity.putExtra("activity_id", activity_id);
+                    nextActivity.putExtra("host_uid", host_uid);
                     itemView.getContext().startActivity(nextActivity);
                 }
             });

--- a/app/src/main/java/com/example/jioleh/listings/HomeFragment.java
+++ b/app/src/main/java/com/example/jioleh/listings/HomeFragment.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.AbsListView;
 import android.widget.ImageView;
 
 import androidx.annotation.NonNull;
@@ -85,6 +86,23 @@ public class HomeFragment extends Fragment {
         activity_list.setHasFixedSize(true);
         activity_list.setLayoutManager(new LinearLayoutManager(this.getContext()));
         activity_list.setAdapter(adapter);
+
+        activity_list.addOnScrollListener(new RecyclerView.OnScrollListener() {
+            @Override
+            public void onScrollStateChanged(@NonNull RecyclerView recyclerView, int newState) {
+                super.onScrollStateChanged(recyclerView, newState);
+            }
+
+            @Override
+            public void onScrolled(@NonNull RecyclerView recyclerView, int dx, int dy) {
+                super.onScrolled(recyclerView, dx, dy);
+
+                LinearLayoutManager linearLayoutManager = (LinearLayoutManager) recyclerView.getLayoutManager();
+                if (linearLayoutManager.findLastCompletelyVisibleItemPosition() == adapter.getItemCount() - 1) {
+                    viewModel.getMoreActivities();
+                }
+            }
+        });
     }
 
     @Override
@@ -113,6 +131,9 @@ public class HomeFragment extends Fragment {
             public void onRefresh() {
                 linesOfChecks.checkActivityExpiry();
                 linesOfChecks.checkActivityCancelledConfirmed();
+
+                viewModel.refreshActivities();
+                adapter.notifyDataSetChanged();
                 swipeRefreshLayout.setRefreshing(false);
             }
         });

--- a/app/src/main/java/com/example/jioleh/listings/JioActivityViewModel.java
+++ b/app/src/main/java/com/example/jioleh/listings/JioActivityViewModel.java
@@ -21,8 +21,16 @@ public class JioActivityViewModel extends ViewModel implements databaseOperation
     }
 
 
-    LiveData<List<JioActivity>> getListOfJioActivities() {
+    public LiveData<List<JioActivity>> getListOfJioActivities() {
         return listOfJioActivities;
+    }
+
+    public void getMoreActivities() {
+        repository.getMoreActivities();
+    }
+
+    public void refreshActivities() {
+        repository.getJioActivityData();
     }
 
     @Override

--- a/app/src/main/java/com/example/jioleh/listings/ViewParticipantsAdapter.java
+++ b/app/src/main/java/com/example/jioleh/listings/ViewParticipantsAdapter.java
@@ -50,7 +50,9 @@ public class ViewParticipantsAdapter extends RecyclerView.Adapter<ViewParticipan
 
     @Override
     public void onBindViewHolder(@NonNull ViewParticipantsAdapter.ParticipantsHolder holder, int position) {
+        holder.setIsRecyclable(false);
         holder.user_id = list_of_uid.get(position);
+        holder.position = position;
         holder.setUpView(list_of_participants.get(position));
     }
 
@@ -59,12 +61,21 @@ public class ViewParticipantsAdapter extends RecyclerView.Adapter<ViewParticipan
         return list_of_participants.size();
     }
 
+    @Override
+    public long getItemId(int position) {
+        return position;
+    }
+
+    @Override
+    public int getItemViewType(int position) {
+        return position;
+    }
+
     public void setData(List<UserProfile> users, List<String> list_of_uid, String host_uid, String activity_id) {
         this.list_of_participants = users;
         this.list_of_uid = list_of_uid;
         this.host_uid = host_uid;
         this.activity_id = activity_id;
-        notifyDataSetChanged();
     }
 
     class ParticipantsHolder extends RecyclerView.ViewHolder {
@@ -75,6 +86,7 @@ public class ViewParticipantsAdapter extends RecyclerView.Adapter<ViewParticipan
         private String imageUrl;
         private String currentUserUid = FirebaseAuth.getInstance().getCurrentUser().getUid();
         private Context currentContext;
+        private int position;
 
         public ParticipantsHolder(@NonNull final View itemView) {
             super(itemView);
@@ -112,8 +124,6 @@ public class ViewParticipantsAdapter extends RecyclerView.Adapter<ViewParticipan
 
             //Allows host to kick participants
             if (currentUserUid.equals(host_uid)) {
-                System.out.println(currentUserUid);
-                System.out.println(user_id);
                 if (!currentUserUid.equals(user_id)) {
                     itemView.setOnLongClickListener(new View.OnLongClickListener() {
                         @Override
@@ -177,6 +187,10 @@ public class ViewParticipantsAdapter extends RecyclerView.Adapter<ViewParticipan
                             datastore.collection("activities")
                                     .document(activity_id)
                                     .update("participants", updatedListParticipants);
+
+                            list_of_uid.remove(position);
+                            list_of_participants.remove(position);
+                            notifyDataSetChanged();
                         }
                     });
         }

--- a/app/src/main/java/com/example/jioleh/login/MainActivity.java
+++ b/app/src/main/java/com/example/jioleh/login/MainActivity.java
@@ -31,7 +31,6 @@ public class MainActivity extends AppCompatActivity {
 
         //Auto-Login
         if (currentUser != null) {
-            Toast.makeText(this, currentUser.getUid(), Toast.LENGTH_SHORT).show();
             Intent nextActivity = new Intent(MainActivity.this, PostLoginPage.class);
             nextActivity.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
             finish();

--- a/app/src/main/java/com/example/jioleh/post/PostingPage.java
+++ b/app/src/main/java/com/example/jioleh/post/PostingPage.java
@@ -392,6 +392,7 @@ public class PostingPage
 
         //this is to set a maximum to both minimum and maximum to ensure that participants array do not get too large which can affect database storage and time complexities when querying
         if (first > 50 || second > 50) {
+            Toast.makeText(this, "Max Participants allowed is 50", Toast.LENGTH_SHORT).show();
             return false;
         }
 

--- a/app/src/main/java/com/example/jioleh/userprofile/OtherUserView.java
+++ b/app/src/main/java/com/example/jioleh/userprofile/OtherUserView.java
@@ -324,7 +324,7 @@ public class OtherUserView extends AppCompatActivity {
     private void alertDeleteDialog() {
         AlertDialog.Builder builder = new AlertDialog.Builder(OtherUserView.this);
 
-        builder.setTitle("Error");
+        builder.setTitle("Oops!");
         builder.setMessage("The user cannot be found.");
         builder.setCancelable(false);
 

--- a/app/src/main/java/com/example/jioleh/userprofile/UserProfileListingViewModel.java
+++ b/app/src/main/java/com/example/jioleh/userprofile/UserProfileListingViewModel.java
@@ -26,7 +26,7 @@ public class UserProfileListingViewModel extends ViewModel implements databaseOp
     }
 
     public void refreshActivities() {
-        this.repository.getActivities(current_uid);
+        this.repository.refreshActivities(current_uid);
     }
 
     @Override

--- a/app/src/main/res/layout/activity_posting_page.xml
+++ b/app/src/main/res/layout/activity_posting_page.xml
@@ -422,7 +422,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
-                app:layout_constraintGuide_percent="0.56" />
+                app:layout_constraintGuide_percent="0.54" />
 
             <androidx.constraintlayout.widget.Guideline
                 android:id="@+id/guideline5"

--- a/app/src/main/res/layout/activity_view_jio.xml
+++ b/app/src/main/res/layout/activity_view_jio.xml
@@ -140,7 +140,6 @@
                 android:layout_height="80dp"
                 android:layout_marginStart="40dp"
                 android:layout_marginLeft="40dp"
-                android:src="@drawable/default_picture"
                 app:layout_constraintBottom_toBottomOf="@+id/vViewDisplayHost"
                 app:layout_constraintStart_toStartOf="@+id/vViewDisplayHost"
                 app:layout_constraintTop_toTopOf="@+id/vViewDisplayHost" />


### PR DESCRIPTION
added check blocked in view activity

added check deleted in view activity

added progress bar in view activity when running to above checks

updated view participants and kick feature(update recyclerview on kick)

fixed user listing duplicate item bug(added refresh in repository, rather than calling get which gets another listener)

fixed chat fragment duplicate item bug(added refresh in repository, rather than calling get which gets another listener)

added pagination to home fragment to load more on scroll rather than laod all activities
(remove home fragment listener becuase it can get quite uneccessarily expensive for user to keep udpating even if he is not on the home fragment)
(added refresh to get latest activities so as to give user the choice as to when he wants to view the lastest updated activities)

added pagination to search activity

ran some feature testing